### PR TITLE
Parameterize the admin username.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@
 #
 class pypi (
   $pypi_http_password = '1234',
+  $pypi_http_username = 'pypiadmin',
   $pypi_port = '80',
   $pypi_root = '/var/pypi',
   ) {
@@ -69,7 +70,7 @@ class pypi (
   }
 
   exec { 'create-htaccess':
-    command => "/usr/bin/htpasswd -sbc ${pypi_root}/.htaccess pypiadmin ${pypi_http_password}",
+    command => "/usr/bin/htpasswd -sbc ${pypi_root}/.htaccess ${pypi_http_username} ${pypi_http_password}",
     user    => 'pypi',
     group   => 'pypi',
     creates => "${pypi_root}/.htaccess",

--- a/spec/classes/pypi_spec.rb
+++ b/spec/classes/pypi_spec.rb
@@ -65,6 +65,7 @@ describe 'pypi', :type => 'class' do
 
     let :params do
       {
+        :pypi_http_username => 'administrator',
         :pypi_http_password => 'TopSecret',
         :pypi_port          => '42',
         :pypi_root          => '/srv/somewhere'
@@ -75,7 +76,7 @@ describe 'pypi', :type => 'class' do
       should contain_exec('create-htaccess').with_command(/TopSecret$/)
       should contain_apache__vhost('pypi').with_port('42')
       should contain_file('pypiserver_wsgi.py').with_content(/pypiserver\.app\('\/srv\/somewhere\/packages.*\/srv\/somewhere\/\.htaccess/)
-      should contain_exec('create-htaccess').with_command(/\/usr\/bin\/htpasswd -sbc \/srv\/somewhere\/\.htaccess pypiadmin/)
+      should contain_exec('create-htaccess').with_command(/\/usr\/bin\/htpasswd -sbc \/srv\/somewhere\/\.htaccess administrator/)
       should contain_exec('create-htaccess').with_creates('/srv/somewhere/.htaccess')
       should contain_apache__vhost('pypi').with_docroot('/srv/somewhere')
     end # it


### PR DESCRIPTION
This patch allows users to define a username other than 'pypiadmin' as
the administive access.  'pypiadmin' remains the default.

Rspec tests were updated to reflect and exercise this new parameter.

Will likely conflict with #4 if that is on the docket to come in soon.
